### PR TITLE
Removing internal modification of the variable names (no more replacing spaces to underscores)

### DIFF
--- a/ggcorr.R
+++ b/ggcorr.R
@@ -202,6 +202,7 @@ ggcorr <- function(
   }
 
   m = cor_matrix
+  names(m) = rownames(m)
 
   # -- correlation data.frame --------------------------------------------------
 

--- a/ggcorr.R
+++ b/ggcorr.R
@@ -202,7 +202,6 @@ ggcorr <- function(
   }
 
   m = cor_matrix
-  colnames(m) = rownames(m) = gsub(" ", "_", colnames(m)) # protect spaces
 
   # -- correlation data.frame --------------------------------------------------
 


### PR DESCRIPTION
I tried to address #10. I ended up using `as_tibble()` to retain variable names with spaces. As a result, I added `tibble` as required. Would this solve the issue? 
(Thanks for the great code btw!)